### PR TITLE
Added player to damage handling

### DIFF
--- a/src/main/kotlin/xyz/fragbots/sandboxcore/entitites/SkyblockEntity.kt
+++ b/src/main/kotlin/xyz/fragbots/sandboxcore/entitites/SkyblockEntity.kt
@@ -2,10 +2,7 @@ package xyz.fragbots.sandboxcore.entitites
 
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.entity.EntityType
-import org.bukkit.entity.Item
-import org.bukkit.entity.LivingEntity
-import org.bukkit.entity.Zombie
+import org.bukkit.entity.*
 import org.bukkit.inventory.ItemStack
 import org.bukkit.metadata.FixedMetadataValue
 import xyz.fragbots.sandboxcore.SandboxCore
@@ -74,15 +71,15 @@ abstract class SkyblockEntity(val name:String){
     }
 
     open fun load(entity:LivingEntity) {}
-    open fun damage(damage: Long) {
+    open fun damage(damage: Long, damagedBy: Player) {
         currentHealth = 0.toLong().coerceAtLeast(currentHealth - damage)
         entity?.customName = generateName()
         if(currentHealth==0.toLong()){
-            kill()
+            kill(damagedBy)
         }
     }
 
-    open fun kill() {
+    open fun kill(killedBy: Player) {
         val ent = entity ?: return
         SandboxCore.instance.entityManager.unRegisterEntity(ent.entityId)
         ent.health=0.0

--- a/src/main/kotlin/xyz/fragbots/sandboxcore/utils/damage/DamageExecutor.kt
+++ b/src/main/kotlin/xyz/fragbots/sandboxcore/utils/damage/DamageExecutor.kt
@@ -35,7 +35,7 @@ class DamageExecutor {
             }
             val finalDamage = damage.toLong()
             createDmgHolo(mob.location,finalDamage,event.isCrit)
-            damagee.damage(finalDamage)
+            damagee.damage(finalDamage,event.player)
             return finalDamage
         }
         return 0
@@ -65,7 +65,7 @@ class DamageExecutor {
             }
             val finalDamage = damage.toLong()
             createDmgHolo(mob.location,finalDamage,event.isCrit)
-            damagee.damage(finalDamage)
+            damagee.damage(finalDamage,event.player)
             return finalDamage
         }
         return 0
@@ -83,7 +83,7 @@ class DamageExecutor {
         if(!event.isCancelled){
             val damage = (event.baseAbilityDamage*event.multipler*event.enchantMultiplier).toLong()
             createDmgHolo(mob.location,damage,false)
-            damagee.damage(damage)
+            damagee.damage(damage,event.player)
             return damage
         }
         return 0


### PR DESCRIPTION
- Damage function in SkyblockEntity now takes player argument to allow for tracking damage for dragons and displaying last hit, might be useful for other mobs too